### PR TITLE
Split datagrams up before handing them to parse_datagram

### DIFF
--- a/src/sick_tim_common.cpp
+++ b/src/sick_tim_common.cpp
@@ -203,9 +203,22 @@ int SickTimCommon::loopOnce()
   }
 
   sensor_msgs::LaserScan msg;
-  int success = parser_->parse_datagram((char*)receiveBuffer, (size_t)actual_length, config_, msg);
-  if (success == EXIT_SUCCESS)
-    diagnosticPub_->publish(msg);
+
+  /*
+   * datagrams are enclosed in <STX> (0x02), <ETX> (0x03) pairs
+   */
+  char* buffer_pos = (char*)receiveBuffer;
+  char *dstart, *dend;
+  while( (dstart = strchr(buffer_pos, 0x02)) && (dend = strchr(buffer_pos, 0x03)) )
+  {
+    size_t dlength = dend - dstart;
+    *dend = '\0';
+    dstart++;
+    int success = parser_->parse_datagram(dstart, dlength, config_, msg);
+    if (success == EXIT_SUCCESS)
+      diagnosticPub_->publish(msg);
+    buffer_pos = dend + 1;
+  }
 
   return EXIT_SUCCESS; // return success to continue looping
 }


### PR DESCRIPTION
This finally fixes the warning on datagrams of invalid length each time
multiple datagrams are read.

Please also fast-forward the indigo branch after merging this!
