### PR TITLE
Auto retry USB and ethernet connections due to any reason.

### DIFF
--- a/src/sick_tim310.cpp
+++ b/src/sick_tim310.cpp
@@ -50,19 +50,29 @@ int main(int argc, char **argv)
 
   sick_tim::SickTim310Parser* parser = new sick_tim::SickTim310Parser();
 
-  sick_tim::SickTimCommon* s;
-  if (subscribe_datagram)
-    s = new sick_tim::SickTimCommonMockup(parser);
-  else
-    s = new sick_tim::SickTimCommonUsb(parser);
+  sick_tim::SickTimCommon* s = NULL;
 
-  int result = s->init();
-  while (ros::ok() && (result == EXIT_SUCCESS))
+  int result = EXIT_FAILURE;
+  while (ros::ok())
   {
-    ros::spinOnce();
-    result = s->loopOnce();
+    // Atempt to connect/reconnect
+    delete s;
+    if (subscribe_datagram)
+      s = new sick_tim::SickTimCommonMockup(parser);
+    else
+      s = new sick_tim::SickTimCommonUsb(parser);
+    result = s->init();
+
+    while(ros::ok() && (result == EXIT_SUCCESS)){
+      ros::spinOnce();
+      result = s->loopOnce();
+    }
+
+    if (ros::ok() && !subscribe_datagram)
+      ros::Duration(1.0).sleep(); // Only attempt USB connections once per second
   }
 
   delete s;
+  delete parser;
   return result;
 }

--- a/src/sick_tim310_1130000m01.cpp
+++ b/src/sick_tim310_1130000m01.cpp
@@ -50,19 +50,29 @@ int main(int argc, char **argv)
 
   sick_tim::SickTim3101130000M01Parser* parser = new sick_tim::SickTim3101130000M01Parser();
 
-  sick_tim::SickTimCommon* s;
-  if (subscribe_datagram)
-    s = new sick_tim::SickTimCommonMockup(parser);
-  else
-    s = new sick_tim::SickTimCommonUsb(parser);
+  sick_tim::SickTimCommon* s = NULL;
 
-  int result = s->init();
-  while (ros::ok() && (result == EXIT_SUCCESS))
+  int result = EXIT_FAILURE;
+  while (ros::ok())
   {
-    ros::spinOnce();
-    result = s->loopOnce();
+    // Atempt to connect/reconnect
+    delete s;
+    if (subscribe_datagram)
+      s = new sick_tim::SickTimCommonMockup(parser);
+    else
+      s = new sick_tim::SickTimCommonUsb(parser);
+    result = s->init();
+
+    while(ros::ok() && (result == EXIT_SUCCESS)){
+      ros::spinOnce();
+      result = s->loopOnce();
+    }
+
+    if (ros::ok() && !subscribe_datagram)
+      ros::Duration(1.0).sleep(); // Only attempt USB connections once per second
   }
 
   delete s;
+  delete parser;
   return result;
 }

--- a/src/sick_tim310s01.cpp
+++ b/src/sick_tim310s01.cpp
@@ -50,19 +50,29 @@ int main(int argc, char **argv)
 
   sick_tim::SickTim310S01Parser* parser = new sick_tim::SickTim310S01Parser();
 
-  sick_tim::SickTimCommon* s;
-  if (subscribe_datagram)
-    s = new sick_tim::SickTimCommonMockup(parser);
-  else
-    s = new sick_tim::SickTimCommonUsb(parser);
+  sick_tim::SickTimCommon* s = NULL;
 
-  int result = s->init();
-  while (ros::ok() && (result == EXIT_SUCCESS))
+  int result = EXIT_FAILURE;
+  while (ros::ok())
   {
-    ros::spinOnce();
-    result = s->loopOnce();
+    // Atempt to connect/reconnect
+    delete s;
+    if (subscribe_datagram)
+      s = new sick_tim::SickTimCommonMockup(parser);
+    else
+      s = new sick_tim::SickTimCommonUsb(parser);
+    result = s->init();
+
+    while(ros::ok() && (result == EXIT_SUCCESS)){
+      ros::spinOnce();
+      result = s->loopOnce();
+    }
+
+    if (ros::ok() && !subscribe_datagram)
+      ros::Duration(1.0).sleep(); // Only attempt USB connections once per second
   }
 
   delete s;
+  delete parser;
   return result;
 }

--- a/src/sick_tim_common.cpp
+++ b/src/sick_tim_common.cpp
@@ -86,7 +86,6 @@ int SickTimCommon::stop_scanner()
 SickTimCommon::~SickTimCommon()
 {
   delete diagnosticPub_;
-  delete parser_;
 
   printf("sick_tim driver exiting.\n");
 }


### PR DESCRIPTION
@mintar @mikeferguson @jspricke 

This pull request enables a more robust driver by resetting the state and attempting to reconnect automatically until the laser enables or ROS shutsdown.

The driver should survive USB disconnects, ethernet disconnects, and laser power disconnects and eventually come back up.
