### PR TITLE
Update package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <build_depend>diagnostic_updater</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>driver_base</build_depend>
-  <build_depend>libusb-1.0-dev</build_depend>
+  <build_depend>libusb-1.0</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
Change the dependency to libusb-1.0.  This change allows the package to build in Ubuntu 14.04 / ROS Indigo.
