### PR TITLE
timestamp diagnostics must take into account time_offset

### DIFF
--- a/src/sick_tim_common.cpp
+++ b/src/sick_tim_common.cpp
@@ -66,7 +66,7 @@ SickTimCommon::SickTimCommon(AbstractParser* parser) :
           // frequency should be target +- 10%.
           diagnostic_updater::FrequencyStatusParam(&expectedFrequency_, &expectedFrequency_, 0.1, 10),
           // timestamp delta can be from 0.0 to 1.3x what it ideally is.
-          diagnostic_updater::TimeStampStatusParam(-1, 1.3 * 1.0/expectedFrequency_));
+          diagnostic_updater::TimeStampStatusParam(-1, 1.3 * 1.0/expectedFrequency_ - config_.time_offset));
   ROS_ASSERT(diagnosticPub_ != NULL);
 }
 


### PR DESCRIPTION
in our setup we have a big time offset due to delay in communications using the USB interface. because of that, the diagnostics fails because the timestamp delay is too big wrt the expected frequency. 
with the current fix, the diagnostic_updater take into account the time_offset parameter.
