### PR TITLE
Automatically reboot scanner in error state

### DIFF
--- a/cfg/SickTim.cfg
+++ b/cfg/SickTim.cfg
@@ -46,5 +46,6 @@ gen.add("intensity",      bool_t,   0, "Whether or not to return intensity value
 gen.add("skip",           int_t,    0, "The number of scans to skip between each measured scan.",                     0,          0,         9)
 gen.add("frame_id",       str_t,    0, "The TF frame in which laser scans will be returned.",                        "laser")
 gen.add("time_offset",    double_t, 0, "An offset to add to the time stamp before publication of a scan [s].",       -0.001,     -0.25, 0.25)
+gen.add("auto_reboot",    bool_t,   0, "Whether or not to reboot laser if it reports an error",                      False)
 
 exit(gen.generate(PACKAGE, "sick_tim", "SickTim"))

--- a/include/sick_tim/sick_tim_common.h
+++ b/include/sick_tim/sick_tim_common.h
@@ -41,6 +41,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 #include <string.h>
 #include <vector>
 
@@ -71,6 +72,12 @@ public:
 
   double get_expected_frequency() const { return expectedFrequency_; }
 
+  /// Send a SOPAS command to the scanner that should cause a soft reset
+  /**
+   * \returns true if reboot command was accepted, false otherwise
+   */
+  virtual bool rebootScanner();
+
 protected:
   virtual int init_device() = 0;
   virtual int init_scanner();
@@ -91,6 +98,13 @@ protected:
    * \param [out] actual_length the actual amount of data written
    */
   virtual int get_datagram(unsigned char* receiveBuffer, int bufferSize, int* actual_length) = 0;
+
+  /// Converts reply from sendSOPASCommand to string
+  /**
+   * \param [in] reply reply from sendSOPASCommand
+   * \returns reply as string with special characters stripped out
+   */
+  static std::string replyToString(const std::vector<unsigned char> &reply);
 
   bool isCompatibleDevice(const std::string identStr) const;
 


### PR DESCRIPTION
Read scanner state during initialization.  Have configuration that will cause driver to request software reboot of scanner if it in error state.

On rare occasions we've seen laser scanner get into an error state where it will respond to most requests but will not start streaming data.   Requesting reboot clears error condition.