### PR TITLE
catkin test-flag around `roslaunch_add_file_check`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,4 +97,6 @@ install(DIRECTORY meshes/
 install(DIRECTORY urdf/
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/urdf)
 
-roslaunch_add_file_check(launch)
+if(CATKIN_ENABLE_TESTING)
+  roslaunch_add_file_check(launch)
+endif(CATKIN_ENABLE_TESTING)


### PR DESCRIPTION
Eval `CATKIN_ENABLE_TESTING` prior to call `roslaunch_add_file_check` to ensure the function is defined.