### PR TITLE
mrs1000 frame_id parameter does not work

### DIFF
--- a/src/sick_mrs1000_communication.cpp
+++ b/src/sick_mrs1000_communication.cpp
@@ -120,7 +120,7 @@ int SickMrs1000Communication::loopOnce()
        * different than layer 0, so don't publish it (because the points
        * don't lie in a plane)
        */
-      if(scan.header.frame_id == "laser")
+      if(scan.header.frame_id != "")
       {
         diagnosticPub_->publish(scan);
       }

--- a/src/sick_mrs1000_parser.cpp
+++ b/src/sick_mrs1000_parser.cpp
@@ -279,7 +279,7 @@ int SickMRS1000Parser::parse_datagram(char* datagram, size_t datagram_length, Si
       ROS_ASSERT_MSG(layer_count_ == 4, "Expected four layers and layer == -500 to be the last layer! Package loss in communication!");
       layer_count_ = 0;
       cloud = cloud_;
-      cloud.header.frame_id = "laser";
+      cloud.header.frame_id = current_config_.frame_id.c_str();
     }
   }
 


### PR DESCRIPTION
if frame_id parameter was defined to something other than "laser", the node would not publish the /scan topic and the /cloud header.frame_id would always be "laser" even if a different one was defined

This fixes both issues