### PR TITLE
[package] run_depend libusb-1.0 -> libusb-1.0-dev

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
 
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>libusb-1.0</run_depend>
+  <run_depend>libusb-1.0-dev</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>sick_tim</name>
   <version>0.0.14</version>
   <description>
@@ -17,19 +17,15 @@
   <url type="repository">https://github.com/uos/sick_tim</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-
-  <build_depend>diagnostic_updater</build_depend>
-  <build_depend>dynamic_reconfigure</build_depend>
-  <build_depend>libusb-1.0-dev</build_depend>
-  <build_depend>roscpp</build_depend>
+  <build_export_depend>libusb-1.0-dev</build_export_depend>
   <build_depend>roslaunch</build_depend>
-  <build_depend>sensor_msgs</build_depend>
 
-  <run_depend>diagnostic_updater</run_depend>
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>libusb-1.0-dev</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>xacro</run_depend>
+  <depend>diagnostic_updater</depend>
+  <depend>dynamic_reconfigure</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+
+  <exec_depend>libusb-1.0-dev</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
 
-  <exec_depend>libusb-1.0-dev</exec_depend>
+  <exec_depend>libusb-1.0</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,11 @@
   <url type="repository">https://github.com/uos/sick_tim</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_export_depend>libusb-1.0-dev</build_export_depend>
+
+  <build_depend>libusb-1.0-dev</build_depend>
   <build_depend>roslaunch</build_depend>
+
+  <build_export_depend>libusb-1.0-dev</build_export_depend>
 
   <depend>diagnostic_updater</depend>
   <depend>dynamic_reconfigure</depend>


### PR DESCRIPTION
Change run_depend to libusb-1.0-dev

CMake Error: Project 'sick_tim' specifies '/usr/include/libusb-1.0' as an include dir, which is not found.

It looks like libusb headers are included in the headers exported by this project, so the **-dev** 
version should be a `<run_depend>` (or `<build_export_depend>` after [REP-140](http://www.ros.org/reps/rep-0140.html)) 

This error occurred on the ROS build farm, oddly on our doc job not the other jobs.
http://build.ros.org/job/Mdoc__fetch_robots__ubuntu_bionic_amd64/2/console

Full error:
```
03:23:52 -- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
03:23:52 CMake Error at /opt/ros/melodic/share/sick_tim/cmake/sick_timConfig.cmake:113 (message):
03:23:52   Project 'sick_tim' specifies '/usr/include/libusb-1.0' as an include dir,
03:23:52   which is not found.  It does neither exist as an absolute directory nor in
03:23:52   '/opt/ros/melodic//usr/include/libusb-1.0'.  Check the website
03:23:52   'http://wiki.ros.org/sick_tim' for information and consider reporting the
03:23:52   problem.
```