### PR TITLE
Make topic name configurable

### DIFF
--- a/cfg/sick_tcp.yaml
+++ b/cfg/sick_tcp.yaml
@@ -16,4 +16,4 @@ sick_driver:
     frame_id: "laser"
     time_offset: -0.001
     publish_datagram: false
-    
+    auto_reboot: true

--- a/cfg/sick_tcp.yaml
+++ b/cfg/sick_tcp.yaml
@@ -12,6 +12,7 @@ sick_driver:
     max_ang: 1.57
     intensity: true
     skip: 0
+    pub_topic_scan: "scan"
     frame_id: "laser"
     time_offset: -0.001
     publish_datagram: false

--- a/cfg/sick_usb.yaml
+++ b/cfg/sick_usb.yaml
@@ -12,6 +12,7 @@ sick_driver:
     max_ang: 2.35619449019
     intensity: true
     skip: 0
+    pub_topic_scan: "scan"
     frame_id: "laser"
     time_offset: -0.001
     publish_datagram: false

--- a/include/sick_tim/sick_tim_config.hpp
+++ b/include/sick_tim/sick_tim_config.hpp
@@ -51,6 +51,7 @@ struct SickTimConfig
   double max_ang;
   bool intensity;
   int skip;
+  std::string pub_topic_scan;
   std::string frame_id;
   double time_offset;
   bool auto_reboot;

--- a/src/sick_tim551_2050001.cpp
+++ b/src/sick_tim551_2050001.cpp
@@ -59,6 +59,7 @@ int main(int argc, char ** argv)
   node->declare_parameter("max_ang", 0.75 * M_PI);
   node->declare_parameter("intensity", true);
   node->declare_parameter("skip", 0);
+  node->declare_parameter("pub_topic_scan", "scan");
   node->declare_parameter("frame_id", "laser");
   node->declare_parameter("time_offset", -0.001);
   node->declare_parameter("auto_reboot", true);

--- a/src/sick_tim_common.cpp
+++ b/src/sick_tim_common.cpp
@@ -79,6 +79,7 @@ SickTimCommon::SickTimCommon(
   config_.max_ang = node_->get_parameter("max_ang").as_double();
   config_.intensity = node_->get_parameter("intensity").as_bool();
   config_.skip = node_->get_parameter("skip").as_int();
+  config_.pub_topic_scan = node_->get_parameter("pub_topic_scan").as_string();
   config_.frame_id = node_->get_parameter("frame_id").as_string();
   config_.time_offset = node_->get_parameter("time_offset").as_double();
   config_.auto_reboot = node_->get_parameter("auto_reboot").as_bool();
@@ -88,7 +89,7 @@ SickTimCommon::SickTimCommon(
   }
 
   // scan publisher
-  pub_ = node_->create_publisher<sensor_msgs::msg::LaserScan>("scan", 1000);
+  pub_ = node_->create_publisher<sensor_msgs::msg::LaserScan>(config_.pub_topic_scan, 1000);
   diagnosticPub_ = new diagnostic_updater::DiagnosedPublisher<sensor_msgs::msg::LaserScan>(
     pub_, *diagnostics_,
     // frequency should be target +- 10%.


### PR DESCRIPTION
The topic name to publish the laserscan can now be configured over the config file.